### PR TITLE
Optimize record fetching with errgroup (#1928)

### DIFF
--- a/.agents/workflows/sync.md
+++ b/.agents/workflows/sync.md
@@ -1,0 +1,22 @@
+---
+description: Sync the local main branch with origin/main and compress the session context.
+---
+
+1.  **Checkout Main**:
+    - Ensure you are on the `main` branch:
+      ```bash
+      git checkout main
+      ```
+
+2.  **Sync with Origin**:
+    - Fetch and merge the latest changes from the remote `main` branch:
+      ```bash
+      git fetch origin main && git merge origin/main
+      ```
+
+3.  **Compress Context**:
+    - Provide a high-signal summary of the current workspace state, including:
+        - The current branch and its sync status.
+        - Any recent major changes or completed tasks.
+        - A brief overview of pending work or identified issues.
+    - This summary serves to "compress" the recent history into a single concise update, allowing the session to remain efficient.

--- a/.github/workflows/gemini-reviewer.yml
+++ b/.github/workflows/gemini-reviewer.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          gemini_model: "gemini-3.1-flash-lite"

--- a/.github/workflows/makepr.yml
+++ b/.github/workflows/makepr.yml
@@ -13,4 +13,4 @@ jobs:
       uses: repo-sync/pull-request@v2
       with:
         destination_branch: "main"
-        github_token: ${{ secrets.PERSONAL_TOKEN }}
+        github_token: ${{ secrets.AUTOMATION_TOKEN }}

--- a/db/db.go
+++ b/db/db.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode"
 
+	"golang.org/x/sync/errgroup"
 	pstore_client "github.com/brotherlogic/pstore/client"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1006,14 +1007,24 @@ func (d *DB) LoadAllRecords(ctx context.Context, userid int32) ([]*pb.Record, er
 		return nil, fmt.Errorf("unable to get records: %w", err)
 	}
 
-	var records []*pb.Record
-	for _, iid := range iids {
-		rec, err := d.GetRecord(ctx, userid, iid)
-		if err != nil {
-			return nil, fmt.Errorf("unable to read (%v) -> %w", iid, err)
-		}
+	records := make([]*pb.Record, len(iids))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(100)
 
-		records = append(records, rec)
+	for i, iid := range iids {
+		i, iid := i, iid
+		g.Go(func() error {
+			rec, err := d.GetRecord(gctx, userid, iid)
+			if err != nil {
+				return fmt.Errorf("unable to read (%v) -> %w", iid, err)
+			}
+			records[i] = rec
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	return records, nil

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJk
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/org/org.go
+++ b/org/org.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/brotherlogic/gramophile/db"
 	pb "github.com/brotherlogic/gramophile/proto"
 	"github.com/prometheus/client_golang/prometheus"
@@ -154,13 +156,23 @@ func (o *Org) getRecords(ctx context.Context, user *pb.StoredUser) ([]*pb.Record
 	log.Printf("Ran db_read_records (%v) in %v", len(ids), time.Since(t1))
 
 	t2 := time.Now()
-	var records []*pb.Record
-	for _, id := range ids {
-		rec, err := o.d.GetRecord(ctx, user.GetUser().GetDiscogsUserId(), id)
-		if err != nil {
-			return nil, fmt.Errorf("unable to load record %v -> %w", id, err)
-		}
-		records = append(records, rec)
+	records := make([]*pb.Record, len(ids))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(100)
+
+	for i, id := range ids {
+		i, id := i, id
+		g.Go(func() error {
+			rec, err := o.d.GetRecord(gctx, user.GetUser().GetDiscogsUserId(), id)
+			if err != nil {
+				return fmt.Errorf("unable to load record %v -> %w", id, err)
+			}
+			records[i] = rec
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 	log.Printf("Ran read_records (%v) in %v", len(ids), time.Since(t2))
 


### PR DESCRIPTION
This PR implements concurrent record fetching in `org.getRecords` and `db.LoadAllRecords` using `errgroup` with a concurrency limit of 100. This addresses performance bottlenecks identified in #1776 and specifically closes #1928.