### PR TITLE
Fix Gemini Model Name in Reviewer Workflow

### DIFF
--- a/.github/workflows/gemini-reviewer.yml
+++ b/.github/workflows/gemini-reviewer.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
-          gemini_model: "gemini-3.1-flash-lite"
+          gemini_model: "gemini-3.1-flash-lite-preview"


### PR DESCRIPTION
The model name `gemini-3.1-flash-lite` was causing 404 errors. Updating it to `gemini-3.1-flash-lite-preview` which is the correct string for the current API version.