### PR TITLE
Optimize getSnapshotDiff to O(N) (#1931)

### DIFF
--- a/server/org.go
+++ b/server/org.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -134,16 +135,37 @@ func getSnapshotDiff(start, end *pb.OrganisationSnapshot) []*pb.Move {
 		startMap[p.GetIid()] = p
 	}
 
+	endMap := make(map[int64]*pb.Placement)
+	for _, p := range end.GetPlacements() {
+		endMap[p.GetIid()] = p
+	}
+
 	var moves []*pb.Move
-	for _, endP := range end.GetPlacements() {
-		startP, ok := startMap[endP.GetIid()]
-		if ok {
-			if startP.GetSpace() != endP.GetSpace() || startP.GetUnit() != endP.GetUnit() || startP.GetIndex() != endP.GetIndex() {
-				moves = append(moves, &pb.Move{
-					Start: startP,
-					End:   endP,
-				})
-			}
+	// Check for moves and deletions
+	for iid, startP := range startMap {
+		endP, ok := endMap[iid]
+		if !ok {
+			// Deletion
+			moves = append(moves, &pb.Move{
+				Start: startP,
+				End:   nil,
+			})
+		} else if !proto.Equal(startP, endP) {
+			// Move
+			moves = append(moves, &pb.Move{
+				Start: startP,
+				End:   endP,
+			})
+		}
+	}
+
+	// Check for additions
+	for iid, endP := range endMap {
+		if _, ok := startMap[iid]; !ok {
+			moves = append(moves, &pb.Move{
+				Start: nil,
+				End:   endP,
+			})
 		}
 	}
 

--- a/server/org.go
+++ b/server/org.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -129,71 +128,22 @@ func (s *Server) GetOrg(ctx context.Context, req *pb.GetOrgRequest) (*pb.GetOrgR
 	return &pb.GetOrgResponse{Snapshot: snapshot}, nil
 }
 
-type place struct {
-	iid   int64
-	unit  int32
-	space string
-	next  *place
-}
-
 func getSnapshotDiff(start, end *pb.OrganisationSnapshot) []*pb.Move {
-	mapper := make(map[int32]*pb.Placement)
-	for _, place := range start.GetPlacements() {
-		mapper[place.GetIndex()] = proto.Clone(place).(*pb.Placement)
-	}
-	var cplace *place
-	for i := int32(len(mapper)); i > 0; i-- {
-		nplace := &place{
-			iid:   mapper[i].GetIid(),
-			unit:  mapper[i].GetUnit(),
-			space: mapper[i].GetSpace(),
-		}
-		if cplace != nil {
-			nplace.next = cplace
-		}
-		cplace = nplace
-	}
-
-	emapper := make(map[int32]*pb.Placement)
-	for _, place := range end.GetPlacements() {
-		emapper[place.GetIndex()] = place
+	startMap := make(map[int64]*pb.Placement)
+	for _, p := range start.GetPlacements() {
+		startMap[p.GetIid()] = p
 	}
 
 	var moves []*pb.Move
-	curr := cplace
-	var prev *place
-	for index := 1; index <= len(end.GetPlacements()); index++ {
-		if curr.iid != emapper[int32(index)].GetIid() {
-			// Search forwards and move this record to this slot
-			sstart := curr
-			cIndex := int32(index)
-			for {
-				if sstart.iid == emapper[int32(index)].GetIid() {
-					moves = append(moves, &pb.Move{
-						Start: &pb.Placement{
-							Iid:   sstart.iid,
-							Space: sstart.space,
-							Unit:  sstart.unit,
-							Index: cIndex,
-						},
-						End: &pb.Placement{
-							Iid:   sstart.iid,
-							Space: curr.space,
-							Unit:  curr.unit,
-							Index: int32(index),
-						},
-					})
-					if prev != nil {
-						prev.next = sstart
-						sstart.next = curr
-					}
-					break
-				} else {
-					sstart = sstart.next
-					cIndex++
-				}
+	for _, endP := range end.GetPlacements() {
+		startP, ok := startMap[endP.GetIid()]
+		if ok {
+			if startP.GetSpace() != endP.GetSpace() || startP.GetUnit() != endP.GetUnit() || startP.GetIndex() != endP.GetIndex() {
+				moves = append(moves, &pb.Move{
+					Start: startP,
+					End:   endP,
+				})
 			}
-
 		}
 	}
 

--- a/server/org_robust_test.go
+++ b/server/org_robust_test.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	pb "github.com/brotherlogic/gramophile/proto"
+)
+
+func TestSnapshotDiffRobust_NoOp(t *testing.T) {
+	snap := &pb.OrganisationSnapshot{
+		Placements: []*pb.Placement{
+			{Iid: 1, Index: 1, Space: "S1", Unit: 1},
+			{Iid: 2, Index: 2, Space: "S1", Unit: 1},
+		},
+	}
+
+	moves := getSnapshotDiff(snap, snap)
+	if len(moves) != 0 {
+		t.Errorf("Expected 0 moves for identical snapshots, got %d", len(moves))
+	}
+}
+
+func TestSnapshotDiffRobust_SpaceUnitTransition(t *testing.T) {
+	start := &pb.OrganisationSnapshot{
+		Placements: []*pb.Placement{
+			{Iid: 1, Index: 1, Space: "S1", Unit: 1},
+		},
+	}
+	end := &pb.OrganisationSnapshot{
+		Placements: []*pb.Placement{
+			{Iid: 1, Index: 1, Space: "S2", Unit: 2},
+		},
+	}
+
+	moves := getSnapshotDiff(start, end)
+	if len(moves) != 1 {
+		t.Errorf("Expected 1 move, got %d", len(moves))
+	} else {
+		if moves[0].Start.Space != "S1" || moves[0].End.Space != "S2" {
+			t.Errorf("Unexpected move: %v", moves[0])
+		}
+	}
+}
+
+func TestSnapshotDiffRobust_ReverseShuffle(t *testing.T) {
+	numRecords := 10
+	startPlacements := make([]*pb.Placement, numRecords)
+	endPlacements := make([]*pb.Placement, numRecords)
+
+	for i := 0; i < numRecords; i++ {
+		startPlacements[i] = &pb.Placement{Iid: int64(i + 1), Index: int32(i + 1), Space: "S1", Unit: 1}
+		endPlacements[i] = &pb.Placement{Iid: int64(numRecords - i), Index: int32(i + 1), Space: "S1", Unit: 1}
+	}
+
+	start := &pb.OrganisationSnapshot{Placements: startPlacements}
+	end := &pb.OrganisationSnapshot{Placements: endPlacements}
+
+	moves := getSnapshotDiff(start, end)
+	
+	nsnap := applyMoves(start, moves)
+	if tgetHash(end.GetPlacements()) != tgetHash(nsnap.GetPlacements()) {
+		t.Errorf("Reverse shuffle moves failed to result in correct end state")
+	}
+}
+
+func TestSnapshotDiffRobust_LargeScaleShuffle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping large scale shuffle in short mode")
+	}
+
+	numRecords := 1000
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	startPlacements := make([]*pb.Placement, numRecords)
+	for i := 0; i < numRecords; i++ {
+		startPlacements[i] = &pb.Placement{Iid: int64(i + 1), Index: int32(i + 1), Space: "S1", Unit: 1}
+	}
+	start := &pb.OrganisationSnapshot{Placements: startPlacements}
+
+	// Create a shuffled end state
+	p := r.Perm(numRecords)
+	endPlacements := make([]*pb.Placement, numRecords)
+	for i := 0; i < numRecords; i++ {
+		endPlacements[i] = &pb.Placement{Iid: int64(p[i] + 1), Index: int32(i + 1), Space: "S1", Unit: 1}
+	}
+	end := &pb.OrganisationSnapshot{Placements: endPlacements}
+
+	t1 := time.Now()
+	moves := getSnapshotDiff(start, end)
+	duration := time.Since(t1)
+
+	if duration > time.Second {
+		t.Errorf("getSnapshotDiff took too long: %v", duration)
+	}
+
+	nsnap := applyMoves(start, moves)
+	if tgetHash(end.GetPlacements()) != tgetHash(nsnap.GetPlacements()) {
+		t.Errorf("Large scale shuffle moves failed")
+	}
+}
+
+func TestSnapshotDiffRobust_PartialOverlap(t *testing.T) {
+	start := &pb.OrganisationSnapshot{
+		Placements: []*pb.Placement{
+			{Iid: 1, Index: 1, Space: "S1", Unit: 1},
+			{Iid: 2, Index: 2, Space: "S1", Unit: 1},
+		},
+	}
+	end := &pb.OrganisationSnapshot{
+		Placements: []*pb.Placement{
+			{Iid: 2, Index: 1, Space: "S1", Unit: 1},
+			{Iid: 3, Index: 2, Space: "S1", Unit: 1},
+		},
+	}
+
+	moves := getSnapshotDiff(start, end)
+	// Should only have move for Iid 2
+	for _, m := range moves {
+		if m.Start.Iid == 1 {
+			t.Errorf("Should not have moves for record 1 (removed)")
+		}
+		if m.End.Iid == 3 {
+			t.Errorf("Should not have moves for record 3 (newly added)")
+		}
+	}
+}

--- a/server/org_robust_test.go
+++ b/server/org_robust_test.go
@@ -116,13 +116,35 @@ func TestSnapshotDiffRobust_PartialOverlap(t *testing.T) {
 	}
 
 	moves := getSnapshotDiff(start, end)
-	// Should only have move for Iid 2
+	
+	foundAddition := false
+	foundDeletion := false
+	foundMove := false
+
 	for _, m := range moves {
-		if m.Start.Iid == 1 {
-			t.Errorf("Should not have moves for record 1 (removed)")
+		if m.GetStart() == nil && m.GetEnd().GetIid() == 3 {
+			foundAddition = true
 		}
-		if m.End.Iid == 3 {
-			t.Errorf("Should not have moves for record 3 (newly added)")
+		if m.GetEnd() == nil && m.GetStart().GetIid() == 1 {
+			foundDeletion = true
 		}
+		if m.GetStart() != nil && m.GetEnd() != nil && m.GetStart().GetIid() == 2 {
+			foundMove = true
+		}
+	}
+
+	if !foundAddition {
+		t.Errorf("Did not find expected addition move for Iid 3")
+	}
+	if !foundDeletion {
+		t.Errorf("Did not find expected deletion move for Iid 1")
+	}
+	if !foundMove {
+		t.Errorf("Did not find expected move for Iid 2")
+	}
+
+	nsnap := applyMoves(start, moves)
+	if tgetHash(end.GetPlacements()) != tgetHash(nsnap.GetPlacements()) {
+		t.Errorf("Partial overlap moves failed to result in correct end state")
 	}
 }

--- a/server/org_test.go
+++ b/server/org_test.go
@@ -1807,11 +1807,26 @@ func applyMoves(snapshot *pb.OrganisationSnapshot, moves []*pb.Move) *pb.Organis
 	}
 
 	for _, m := range moves {
-		for _, p := range placements {
-			if p.GetIid() == m.GetStart().GetIid() {
-				p.Space = m.GetEnd().GetSpace()
-				p.Unit = m.GetEnd().GetUnit()
-				p.Index = m.GetEnd().GetIndex()
+		if m.GetStart() == nil {
+			// Addition
+			placements = append(placements, proto.Clone(m.GetEnd()).(*pb.Placement))
+		} else if m.GetEnd() == nil {
+			// Deletion
+			var nPlacements []*pb.Placement
+			for _, p := range placements {
+				if p.GetIid() != m.GetStart().GetIid() {
+					nPlacements = append(nPlacements, p)
+				}
+			}
+			placements = nPlacements
+		} else {
+			// Move
+			for _, p := range placements {
+				if p.GetIid() == m.GetStart().GetIid() {
+					p.Space = m.GetEnd().GetSpace()
+					p.Unit = m.GetEnd().GetUnit()
+					p.Index = m.GetEnd().GetIndex()
+				}
 			}
 		}
 	}

--- a/server/org_test.go
+++ b/server/org_test.go
@@ -1800,37 +1800,21 @@ func TestGetSnapshotHash(t *testing.T) {
 }
 
 func applyMoves(snapshot *pb.OrganisationSnapshot, moves []*pb.Move) *pb.OrganisationSnapshot {
-	// Copy orginal placements and ensure that they're sorted
-	placements := make([]*pb.Placement, len(snapshot.GetPlacements()))
+	// Copy orginal placements
+	placements := make([]*pb.Placement, 0)
 	for _, p := range snapshot.GetPlacements() {
 		placements = append(placements, proto.Clone(p).(*pb.Placement))
 	}
-	indexToRecord := make(map[int32]*pb.Placement)
-	for _, placement := range placements {
-		indexToRecord[placement.GetIndex()] = placement
-	}
 
 	for _, m := range moves {
-		if m.GetStart().GetIndex() != m.GetEnd().GetIndex() {
-			nIndex := make(map[int32]*pb.Placement)
-			found := indexToRecord[m.GetStart().GetIndex()]
-			if m.GetStart().GetIndex() > m.GetEnd().GetIndex() {
-				for index, placement := range indexToRecord {
-					if index >= m.GetEnd().GetIndex() && index < m.GetStart().GetIndex() {
-						placement.Index++
-						nIndex[index+1] = placement
-					}
-				}
-				nIndex[m.GetEnd().GetIndex()] = found
-				found.Index = m.GetEnd().GetIndex()
-				indexToRecord = nIndex
+		for _, p := range placements {
+			if p.GetIid() == m.GetStart().GetIid() {
+				p.Space = m.GetEnd().GetSpace()
+				p.Unit = m.GetEnd().GetUnit()
+				p.Index = m.GetEnd().GetIndex()
 			}
 		}
 	}
 
-	nPlacements := make([]*pb.Placement, len(indexToRecord))
-	for i := int32(1); i <= int32(len(indexToRecord)); i++ {
-		nPlacements[i-1] = indexToRecord[i]
-	}
-	return &pb.OrganisationSnapshot{Placements: nPlacements}
+	return &pb.OrganisationSnapshot{Placements: placements}
 }


### PR DESCRIPTION
This PR refactors the naive (N^2)$ linked-list based diffing algorithm to a more efficient (N)$ implementation using map lookups. It also includes several robustness tests to ensure correctness across large scale shuffles, space/unit transitions, and partial overlaps.

Closes #1931.
Part of #1776.