### PR TITLE
Fix nested GetFormat loop (#1932)

### DIFF
--- a/background/moves.go
+++ b/background/moves.go
@@ -25,25 +25,30 @@ func applyMove(m *pb.RecordMove, r *pb.Record, class string, format string) stri
 }
 
 func (b *BackgroundRunner) GetFormat(ctx context.Context, record *pb.Record, fc *pb.FormatClassifier) string {
+	allDescriptions := make(map[string]struct{})
+	allNames := make(map[string]struct{})
+	for _, rform := range record.GetRelease().GetFormats() {
+		allNames[rform.GetName()] = struct{}{}
+		for _, rdesc := range rform.GetDescriptions() {
+			allDescriptions[rdesc] = struct{}{}
+		}
+	}
+
 	for _, classifier := range fc.GetFormats() {
 		description := len(classifier.GetDescription()) == 0
 		names := len(classifier.GetContains()) == 0
 
 		for _, desc := range classifier.GetDescription() {
-			for _, rform := range record.GetRelease().GetFormats() {
-				for _, rdesc := range rform.GetDescriptions() {
-					if rdesc == desc {
-						description = true
-					}
-				}
+			if _, ok := allDescriptions[desc]; ok {
+				description = true
+				break
 			}
 		}
 
 		for _, name := range classifier.GetContains() {
-			for _, rform := range record.GetRelease().GetFormats() {
-				if rform.GetName() == name {
-					names = true
-				}
+			if _, ok := allNames[name]; ok {
+				names = true
+				break
 			}
 		}
 

--- a/background/moves.go
+++ b/background/moves.go
@@ -26,24 +26,23 @@ func applyMove(m *pb.RecordMove, r *pb.Record, class string, format string) stri
 
 func (b *BackgroundRunner) GetFormat(ctx context.Context, record *pb.Record, fc *pb.FormatClassifier) string {
 	for _, classifier := range fc.GetFormats() {
-		description := false
-		names := false
+		description := len(classifier.GetDescription()) == 0
+		names := len(classifier.GetContains()) == 0
 
-		for _, form := range fc.GetFormats() {
-			for _, desc := range form.GetDescription() {
-				for _, rform := range record.GetRelease().GetFormats() {
-					for _, rdesc := range rform.GetDescriptions() {
-						if rdesc == desc {
-							description = true
-						}
+		for _, desc := range classifier.GetDescription() {
+			for _, rform := range record.GetRelease().GetFormats() {
+				for _, rdesc := range rform.GetDescriptions() {
+					if rdesc == desc {
+						description = true
 					}
 				}
 			}
-			for _, name := range form.GetContains() {
-				for _, rform := range record.GetRelease().GetFormats() {
-					if rform.GetName() == name {
-						names = true
-					}
+		}
+
+		for _, name := range classifier.GetContains() {
+			for _, rform := range record.GetRelease().GetFormats() {
+				if rform.GetName() == name {
+					names = true
 				}
 			}
 		}


### PR DESCRIPTION
This PR removes a redundant (M^2)$ nested loop in `background/moves.go:GetFormat` and fixes the format classifier matching logic to correctly evaluate only the current classifier against the record's formats.

Closes #1932.
Part of #1776.