### PR TITLE
Optimize Classify: pre-sort rules and cache snapshots (#1933)

### DIFF
--- a/background/moves.go
+++ b/background/moves.go
@@ -75,13 +75,14 @@ func (b *BackgroundRunner) RunMoves(ctx context.Context, user *pb.StoredUser, en
 
 	log.Printf("Running %v moves on %v records", len(moves), len(records))
 
+	classifier := classification.CreateClassifier(user.GetConfig().GetClassificationConfig(), b.db, user.GetUser().GetDiscogsUserId())
 	for _, iid := range records {
 		record, err := b.db.GetRecord(ctx, user.GetUser().GetDiscogsUserId(), iid)
 		if err != nil {
 			return err
 		}
 		// Get record classification
-		class := classification.Classify(ctx, record, user.GetConfig().GetClassificationConfig(), user.GetConfig().GetOrganisationConfig(), b.db, user.GetUser().GetDiscogsUserId())
+		class := classifier.Classify(ctx, record)
 
 		format := b.GetFormat(ctx, record, user.GetConfig().GetMovingConfig().GetFormatClassifier())
 

--- a/classification/classification.go
+++ b/classification/classification.go
@@ -52,11 +52,6 @@ func (c *Classifier) Classify(ctx context.Context, r *pb.Record) string {
 	return ""
 }
 
-func Classify(ctx context.Context, r *pb.Record, config *pb.ClassificationConfig, org *pb.OrganisationConfig, db db.Database, uid int32) string {
-	classifier := CreateClassifier(config, db, uid)
-	return classifier.Classify(ctx, r)
-}
-
 func validateDuration(d string) error {
 	_, err := time.ParseDuration(d)
 	if err != nil {
@@ -134,11 +129,6 @@ func (c *Classifier) ApplyRule(ctx context.Context, rule *pb.ClassificationRule,
 	return false
 }
 
-func ApplyRule(ctx context.Context, rule *pb.ClassificationRule, record *pb.Record, db db.Database, uid int32) bool {
-	classifier := &Classifier{db: db, uid: uid, locationCache: make(map[string]map[int64]bool)}
-	return classifier.ApplyRule(ctx, rule, record)
-}
-
 func (c *Classifier) ApplyLocationSelector(ctx context.Context, l string, record *pb.Record) bool {
 	if _, ok := c.locationCache[l]; !ok {
 		org, err := c.db.GetLatestSnapshot(ctx, c.uid, l)
@@ -154,11 +144,6 @@ func (c *Classifier) ApplyLocationSelector(ctx context.Context, l string, record
 	}
 
 	return c.locationCache[l][record.GetRelease().GetInstanceId()]
-}
-
-func ApplyLocationSelector(ctx context.Context, l string, record *pb.Record, db db.Database, userid int32) bool {
-	classifier := &Classifier{db: db, uid: userid, locationCache: make(map[string]map[int64]bool)}
-	return classifier.ApplyLocationSelector(ctx, l, record)
 }
 
 func ApplyBooleanSelector(b *pb.BooleanSelector, r *pb.Record) bool {

--- a/classification/classification.go
+++ b/classification/classification.go
@@ -14,15 +14,32 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-func Classify(ctx context.Context, r *pb.Record, config *pb.ClassificationConfig, org *pb.OrganisationConfig, db db.Database, uid int32) string {
+type Classifier struct {
+	rules         []*pb.Classifier
+	locationCache map[string]map[int64]bool
+	db            db.Database
+	uid           int32
+}
+
+func CreateClassifier(config *pb.ClassificationConfig, db db.Database, uid int32) *Classifier {
 	rules := config.GetClassifiers()
 	sort.SliceStable(rules, func(i, j int) bool {
 		return rules[i].GetPriority() < rules[j].GetPriority()
 	})
-	for _, ruleSet := range rules {
+
+	return &Classifier{
+		rules:         rules,
+		locationCache: make(map[string]map[int64]bool),
+		db:            db,
+		uid:           uid,
+	}
+}
+
+func (c *Classifier) Classify(ctx context.Context, r *pb.Record) string {
+	for _, ruleSet := range c.rules {
 		pass := true
 		for _, rule := range ruleSet.GetRules() {
-			if !ApplyRule(ctx, rule, r, db, uid) {
+			if !c.ApplyRule(ctx, rule, r) {
 				pass = false
 				continue
 			}
@@ -33,6 +50,11 @@ func Classify(ctx context.Context, r *pb.Record, config *pb.ClassificationConfig
 	}
 
 	return ""
+}
+
+func Classify(ctx context.Context, r *pb.Record, config *pb.ClassificationConfig, org *pb.OrganisationConfig, db db.Database, uid int32) string {
+	classifier := CreateClassifier(config, db, uid)
+	return classifier.Classify(ctx, r)
 }
 
 func validateDuration(d string) error {
@@ -98,7 +120,7 @@ func ValidateSelector(s string, ty protoreflect.Kind) error {
 	return status.Errorf(codes.NotFound, "Boolean field %v not found in record proto", s)
 }
 
-func ApplyRule(ctx context.Context, rule *pb.ClassificationRule, record *pb.Record, db db.Database, uid int32) bool {
+func (c *Classifier) ApplyRule(ctx context.Context, rule *pb.ClassificationRule, record *pb.Record) bool {
 	switch rule.GetSelector().(type) {
 	case *pb.ClassificationRule_BooleanSelector:
 		return ApplyBooleanSelector(rule.GetBooleanSelector(), record)
@@ -107,25 +129,36 @@ func ApplyRule(ctx context.Context, rule *pb.ClassificationRule, record *pb.Reco
 	case *pb.ClassificationRule_DateSinceSelector:
 		return ApplyDateSinceSelector(rule.GetDateSinceSelector(), record)
 	case *pb.ClassificationRule_LocationSelector:
-		return ApplyLocationSelector(ctx, rule.GetLocationSelector().GetLocation(), record, db, uid)
+		return c.ApplyLocationSelector(ctx, rule.GetLocationSelector().GetLocation(), record)
 	}
 	return false
 }
 
-func ApplyLocationSelector(ctx context.Context, l string, record *pb.Record, db db.Database, userid int32) bool {
-	org, err := db.GetLatestSnapshot(ctx, userid, l)
-	if err != nil {
-		log.Printf("Unable to get latest snapshot for %v -> %v", l, err)
-	}
+func ApplyRule(ctx context.Context, rule *pb.ClassificationRule, record *pb.Record, db db.Database, uid int32) bool {
+	classifier := &Classifier{db: db, uid: uid, locationCache: make(map[string]map[int64]bool)}
+	return classifier.ApplyRule(ctx, rule, record)
+}
 
-	log.Printf("Placements: %v", org.GetPlacements())
-	for _, placement := range org.GetPlacements() {
-		if placement.GetIid() == record.GetRelease().GetInstanceId() {
-			return true
+func (c *Classifier) ApplyLocationSelector(ctx context.Context, l string, record *pb.Record) bool {
+	if _, ok := c.locationCache[l]; !ok {
+		org, err := c.db.GetLatestSnapshot(ctx, c.uid, l)
+		if err != nil {
+			log.Printf("Unable to get latest snapshot for %v -> %v", l, err)
+			return false
+		}
+
+		c.locationCache[l] = make(map[int64]bool)
+		for _, placement := range org.GetPlacements() {
+			c.locationCache[l][placement.GetIid()] = true
 		}
 	}
 
-	return false
+	return c.locationCache[l][record.GetRelease().GetInstanceId()]
+}
+
+func ApplyLocationSelector(ctx context.Context, l string, record *pb.Record, db db.Database, userid int32) bool {
+	classifier := &Classifier{db: db, uid: userid, locationCache: make(map[string]map[int64]bool)}
+	return classifier.ApplyLocationSelector(ctx, l, record)
 }
 
 func ApplyBooleanSelector(b *pb.BooleanSelector, r *pb.Record) bool {

--- a/classification/classification_test.go
+++ b/classification/classification_test.go
@@ -104,8 +104,9 @@ var applicationTestCases = []struct {
 }
 
 func TestClassificationApplication(t *testing.T) {
+	classifier := &Classifier{db: db.NewTestDB(pstore_client.GetTestClient()), uid: 12, locationCache: make(map[string]map[int64]bool)}
 	for _, tc := range applicationTestCases {
-		res := ApplyRule(context.Background(), tc.rule, tc.record, db.NewTestDB(pstore_client.GetTestClient()), 12)
+		res := classifier.ApplyRule(context.Background(), tc.rule, tc.record)
 		if res != tc.result {
 			t.Errorf("Failure in %v: expected %v, got %v", tc.name, tc.result, res)
 		}

--- a/classification/full_classification_test.go
+++ b/classification/full_classification_test.go
@@ -109,7 +109,8 @@ func TestClassification(t *testing.T) {
 		}
 		db.SaveSnapshot(context.Background(), user, "Listening Pile", snap)
 
-		classification := Classify(context.Background(), tc.record, classificationConfig, orgConfig, db, 12)
+		classifier := CreateClassifier(classificationConfig, db, 12)
+		classification := classifier.Classify(context.Background(), tc.record)
 		if classification != tc.result {
 			t.Errorf("Failure in %v: expected %v, got %v", tc.name, tc.result, classification)
 		}

--- a/server/getrecord.go
+++ b/server/getrecord.go
@@ -73,8 +73,9 @@ func (s *Server) GetRecord(ctx context.Context, req *pb.GetRecordRequest) (*pb.G
 	}
 
 	// Classifiy out the records
+	classifier := classification.CreateClassifier(u.GetConfig().GetClassificationConfig(), s.d, u.GetUser().GetDiscogsUserId())
 	for _, r := range resp.GetRecords() {
-		r.Category = classification.Classify(ctx, r.GetRecord(), u.GetConfig().GetClassificationConfig(), u.GetConfig().GetOrganisationConfig(), s.d, u.GetUser().GetDiscogsUserId())
+		r.Category = classifier.Classify(ctx, r.GetRecord())
 	}
 
 	return resp, err


### PR DESCRIPTION
This PR optimizes the record classification process by:
1. Introducing a stateful `Classifier` struct that pre-sorts classification rules once.
2. Caching location snapshots in a map of `iid -> bool` to avoid redundant DB reads and (N)$ list traversals during location selector evaluation.
3. Updating call sites in `server/getrecord.go` and `background/moves.go` to instantiate the classifier once per batch operation.

Closes #1933.
Part of #1776.