### PR TITLE
Update base Docker images to debian12 to fix x509 cert expiry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN CGO_ENABLED=0 go build -o /gramophile
 ##
 ## Deploy
 ##
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base-debian12
 
 WORKDIR /
 

--- a/overseer/Dockerfile
+++ b/overseer/Dockerfile
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 go build -o /overseer
 ##
 ## Deploy
 ##
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base-debian12
 
 WORKDIR /
 

--- a/prober/Dockerfile
+++ b/prober/Dockerfile
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 go build -o /gramophile-prober
 ##
 ## Deploy
 ##
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base-debian12
 
 WORKDIR /
 

--- a/queue/Dockerfile
+++ b/queue/Dockerfile
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=0 go build -o /gramophile-queue ./queue
 ##
 ## Deploy
 ##
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base-debian12
 
 WORKDIR /
 

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=0 go build -o /gramophile-validator ./validator
 ##
 ## Deploy
 ##
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base-debian12
 
 WORKDIR /
 


### PR DESCRIPTION
The base-debian11 images have outdated CA certificates causing x509 certificate expiry errors when calling external APIs like Discogs. Updating the distroless base images to debian12 resolves this by providing fresh root certificates.